### PR TITLE
Update deprecated selectors

### DIFF
--- a/styles/batman-editor.less
+++ b/styles/batman-editor.less
@@ -2,11 +2,11 @@
 @import 'syntax-variables';
 
 atom-text-editor[mini] .scroll-view,
-:host([mini]) .scroll-view {
-    padding-left: 1px;
+atom-text-editor .scroll-view {
+  padding-left: 1px;
 }
 
-atom-text-editor::shadow {
+atom-text-editor.editor {
     // fix for cursor disappearing under wrap guide
     .wrap-guide {
         background-color: @syntax-wrap-guide-color;
@@ -17,8 +17,7 @@ atom-text-editor::shadow {
     }
 }
 
-atom-text-editor,
-:host {
+atom-text-editor {
     background-color: @syntax-background-color;
     color: @syntax-text-color;
 
@@ -78,13 +77,11 @@ atom-text-editor,
     }
 }
 
-atom-text-editor .search-results .marker .region,
-:host .search-results .marker .region {
+atom-text-editor .search-results .syntax--marker .region {
     background-color: transparent;
     border: 1px solid @syntax-result-marker-color;
 }
 
-atom-text-editor .search-results .marker.current-result .region,
-:host .search-results .marker.current-result .region {
+atom-text-editor .search-results .syntax--marker.current-result .region {
     border: 1px solid @syntax-result-marker-color-selected;
 }

--- a/styles/batman-syntax.less
+++ b/styles/batman-syntax.less
@@ -1,291 +1,315 @@
 @import 'colors';
 @import 'syntax-variables';
 
-.comment {
+.syntax {
+  &--comment {
     color: @syntax-color-comment;
-}
+  }
 
-.constant {
+  &--constant {
     color: @syntax-color-constant;
 
-    &.character.escape {
+    &.syntax {
+      &--character&--escape {
         color: @batman_teal;
 
-        &.python {
-            color: @batman_banana;
+        &.syntax--python {
+          color: @batman_banana;
         }
-    }
+      }
 
-    // &.numeric {
-    //     color: @syntax-color-value;
-    // }
+      // &--numeric {
+      //     color: @syntax-color-value;
+      // }
 
-    &.other.color {
+      &--other&--color {
         color: @batman_teal;
-    }
+      }
 
-    &.other.symbol {
+      &--other&--symbol {
         color: @batman_leaf;
+      }
     }
-}
+  }
 
-.css {
-    &.class {
+  &--css {
+    &.syntax {
+      &--class {
         color: @batman_purple;
-    }
+      }
 
-    &.pseudo-element {
+      &--pseudo-element {
         color: @batman_apple;
+      }
     }
-}
+  }
 
-.entity {
-    &.name.function {
+  &--entity {
+    &.syntax {
+      &--name&--function {
         color: @syntax-color-function;
-    }
+      }
 
-    &.name.type,
-    &.name.class,
-    &.name.type.class {
+      &--name&--type,
+      &--name&--class,
+      &--name&--type&--class {
         color: @syntax-color-class;
-    }
+      }
 
-    &.name.section {
+      &--name&--section {
         color: @batman_khaki;
-    }
+      }
 
-    &.name.tag {
+      &--name&--tag {
         color: @batman_scrubs;
-    }
+      }
 
-    &.id {
+      &--id {
         color: @batman_emerald;
-    }
+      }
 
-    &.inherited-class {
+      &--inherited-class {
         color: @batman_cream;
+      }
     }
-}
+  }
 
-.html {
-    &.punctuation.definition.tag {
-        color: @batman_scrubs;
+  &--html {
+    &.syntax--punctuation.syntax--definition.syntax--tag {
+      color: @batman_scrubs;
     }
-}
+  }
 
-.invalid.illegal {
+  &--invalid&--illegal {
     background-color: @batman_strawberry;
     color: @syntax-background-color;
-}
+  }
 
-.keyword {
+  &--keyword {
     color: @syntax-color-keyword;
 
-    &.control {
+    &.syntax {
+      &--control {
         color: @batman_khaki;
-    }
+      }
 
-    &.operator {
+      &--operator {
         color: @syntax-text-color;
-    }
+      }
 
-    &.operator.python {
+      &--operator&--python {
         color: @batman_scrubs;
-    }
+      }
 
-    &.other.special-method {
+      &--other&--special-method {
         color: @batman_mustard;
-    }
+      }
 
-    &.other.unit {
+      &--other&--unit {
         color: @batman_mustard;
-    }
+      }
 
-    &.control.exception {
+      &--control&--exception {
         color: @batman_raspberry;
+      }
     }
-}
+  }
 
-.markup {
-    &.bold {
+  &--markup {
+    &.syntax {
+      &--bold {
         color: @batman_egg;
         font-weight: bold;
-    }
+      }
 
-    &.changed {
+      &--changed {
         color: @batman_lilac;
-    }
+      }
 
-    &.deleted {
+      &--deleted {
         color: @batman_strawberry;
-    }
+      }
 
-    &.italic {
+      &--italic {
         color: @batman_purple;
         font-style: italic;
-    }
+      }
 
-    &.heading .punctuation.definition.heading {
+      &--heading &--punctuation&--definition&--heading {
         color: @batman_emerald;
-    }
+      }
 
-    &.inserted {
+      &--inserted {
         color: @batman_leaf;
-    }
+      }
 
-    &.list {
+      &--list {
         color: @batman_strawberry;
-    }
+      }
 
-    &.quote {
+      &--quote {
         color: @batman_egg;
-    }
+      }
 
-    &.raw.inline {
+      &--raw&--inline {
         color: @batman_leaf;
+      }
     }
-}
+  }
 
-.meta {
-    &.class {
+  &--meta {
+    &.syntax {
+      &--class {
         color: @batman_cream;
-    }
+      }
 
-    &.link {
+      &--link {
         color: @batman_raspberry;
-    }
+      }
 
-    &.require {
+      &--require {
         color: @batman_apple;
-    }
+      }
 
-    &.selector {
+      &--selector {
         color: @batman_purple;
-    }
+      }
 
-    &.separator {
+      &--separator {
         background-color: @gray_50;
         color: @syntax-text-color;
-    }
+      }
 
-    &.function-call {
+      &--function-call {
         color: @batman_cream;
+      }
     }
-}
+  }
 
-.none {
+  &--none {
     color: @syntax-text-color;
-}
+  }
 
-.punctuation {
-    &.definition {
-        &.comment {
-            color: @syntax-color-comment;
+  &--punctuation {
+    &.syntax--definition {
+      &.syntax {
+        &--comment {
+          color: @syntax-color-comment;
         }
 
-        &.string {
-            color: @batman_teal;
+        &--string {
+          color: @batman_teal;
         }
 
-        &.parameters,
-        &.array {
-            color: @syntax-text-color;
+        &--parameters,
+        &--array {
+          color: @syntax-text-color;
         }
 
-        &.variable {
-            color: @syntax-color-variable;
+        &--variable {
+          color: @syntax-color-variable;
         }
 
-        &.heading,
-        &.identity {
-            color: @batman_teal;
+        &--heading,
+        &--identity {
+          color: @batman_teal;
         }
 
-        &.bold {
-            color: @batman_mustard;
-            font-weight: bold;
+        &--bold {
+          color: @batman_mustard;
+          font-weight: bold;
         }
 
-        &.italic {
-            color: @batman_purple;
-            font-style: italic;
+        &--italic {
+          color: @batman_purple;
+          font-style: italic;
         }
+      }
     }
 
-    &.section.embedded {
-        color: darken(@batman_strawberry, 10%);
+    &.syntax--section.syntax--embedded {
+      color: darken(@batman_strawberry, 10%);
     }
-}
+  }
 
-.source.gfm {
-    .link {
+  &--source&--gfm {
+    .syntax {
+      &--link {
         color: @batman_teal;
 
-        &.markup {
-            color: @batman_mustard;
+        &.syntax--markup {
+          color: @batman_mustard;
         }
-    }
+      }
 
-    .heading {
+      &--heading {
         color: @batman_khaki;
-    }
+      }
 
-    .markup.code {
+      &--markup&--code {
         color: @batman_khaki;
+      }
     }
-}
+  }
 
-.storage {
+  &--storage {
     color: @batman_purple;
 
-    &.modifier {
-        color: @batman_scrubs;
+    &.syntax--modifier {
+      color: @batman_scrubs;
 
-        &.extends,
-        &.implements {
-            color: @batman_purple;
-        }
+      &.syntax--extends,
+      &.syntax--implements {
+        color: @batman_purple;
+      }
     }
-}
+  }
 
-.string {
+  &--string {
     color: @batman_teal;
 
-    &.regexp {
+    &.syntax {
+      &--regexp {
         color: @batman_emerald;
 
-        .source.ruby.embedded {
-            color: @undecided;
+        .syntax--source.syntax--ruby.syntax--embedded {
+          color: @undecided;
         }
-    }
+      }
 
-    &.other.link {
+      &--other&--link {
         color: @undecided;
+      }
     }
-}
+  }
 
-.support {
-    &.class {
+  &--support {
+    &.syntax {
+      &--class {
         color: @batman_cream;
-    }
+      }
 
-    &.function  {
+      &--function  {
         color: @gray_75;
 
-        &.any-method {
-            color: @gray_75;
+        &.syntax--any-method {
+          color: @gray_75;
         }
+      }
     }
-}
+  }
 
-.variable {
+  &--variable {
     color: @batman_banana;
 
-    &.interpolation {
+    &.syntax {
+      &--interpolation {
         color: darken(@batman_strawberry, 10%);
-    }
+      }
 
-    &.parameter.function {
+      &--parameter&--function {
         color: @syntax-text-color;
+      }
     }
+  }
 }


### PR DESCRIPTION
Atom has been pestering me with this deprecation message:

> Starting from Atom v1.13.0, the contents of atom-text-editor elements are no longer encapsulated within a shadow DOM boundary. This means you should stop using :host and ::shadow pseudo-selectors, and prepend all your syntax selectors with syntax--. To prevent breakage with existing style sheets, Atom will automatically upgrade the following selectors..

The syntax still works, but they also note that in a few release cycles they will stop automatically upgrading, so I went ahead and updated the selectors. I tested locally and the deprecation warning was removed.

Thanks for the theme! I use it every day and it makes my eyes very happy.